### PR TITLE
Check garry's mod familiarity

### DIFF
--- a/pointshop2/lua/ps2/server/sv_pointshopcontroller_shop.lua
+++ b/pointshop2/lua/ps2/server/sv_pointshopcontroller_shop.lua
@@ -440,7 +440,15 @@ function Pointshop2Controller:equipItem( ply, itemId, slotName )
 			if item.class:IsValidForServer( Pointshop2.GetCurrentServerId( ) ) then
 				item:OnEquip(  )
 				hook.Run( "PS2_EquipItem", ply, item.id, slotsused )
-				self:startView( "Pointshop2View", "playerEquipItem", player.GetAll( ), ply.kPlayerId, item )
+				local recipients = player.GetAll()
+				local batchSize = 16
+				for i = 1, #recipients, batchSize do
+					local batch = {}
+					for j = i, math.min(i + batchSize - 1, #recipients) do
+						batch[#batch + 1] = recipients[j]
+					end
+					self:startView( "Pointshop2View", "playerEquipItem", batch, ply.kPlayerId, item )
+				end
 			end
 		end )
 


### PR DESCRIPTION
Batch Pointshop2 item network updates to mitigate server crashes when new items are added/equipped.

When new items (skins, playermodels) are added or equipped, Pointshop2 broadcasts large network messages to all players at once. This can cause significant server load spikes and crashes, especially with many players. This change distributes these updates in smaller batches to reduce peak load.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f996dc4-e9a0-4149-b25a-72bd3a12a10e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f996dc4-e9a0-4149-b25a-72bd3a12a10e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

